### PR TITLE
Dpkw 20 命令行增加某个策略的状态

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "start_server": "cross-env NODE_ENV=development PORT=47147 node ./public/server/index.js",
         "dev_server": "cross-env NODE_ENV=development PORT=47147 nodemon --watch ./ --exec babel-node ./public/server/index.js",
-        "dev_cli": "node ./public/cli/index.js",
+        "dev_cli": "node --trace-warnings ./public/cli/index.js",
         "dev_gui": "vite --config public/gui/vite.config.js",
         "build": "rm -rf dist && vite build --config public/gui/vite.config.js && rollup -c rollup_server.config.js && rollup -c rollup_cli.config.js",
         "test": "NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --runInBand",

--- a/policy/cli/policy_cli.js
+++ b/policy/cli/policy_cli.js
@@ -1,5 +1,7 @@
 import cli_utils from '../../public/lib/cli_utils.js';
 import policy_detail_cli from './policy_detail_cli.js';
+import policy_lib from '../lib/policy_lib.js';
+import state_cli from './state_cli.js';
 export default {
     command: 'policy',
     name: '策略管理',
@@ -9,8 +11,66 @@ export default {
         let ins = this;
         const vorpal = cli_utils.create_vorpal();
         this._vorpalInstance = vorpal;
-        cli_utils.add_sub_cli(vorpal, policy_detail_cli, prompt);
-        vorpal.delimiter(prompt)
+        vorpal.delimiter(prompt);
+        vorpal.command('policy <name>', '创建/进入策略')
+            .action(async function (args) {
+                try {
+                    const result = await policy_lib.add_policy(args.name);
+                    if (result && result.result) {
+                        this.log(`已创建策略: ${args.name}`);
+                        // 创建新的视图实例
+                        const newVorpal = cli_utils.create_vorpal();
+                        // 注册状态命令
+                        state_cli.policy_name = args.name;
+                        cli_utils.add_sub_cli(newVorpal, state_cli, `sw_cli> policy-${args.name}>`);
+                        newVorpal.delimiter(`sw_cli> policy-${args.name}>`);
+
+                        // 添加返回命令
+                        newVorpal.command('return', '返回上一级视图')
+                            .action(function() {
+                                newVorpal.hide();
+                                vorpal.show();
+                                vorpal.delimiter('sw_cli> policy>');
+                                return vorpal;
+                            });
+
+                        // 添加 bdr 命令
+                        newVorpal.command('bdr', '列出所有配置')
+                            .action(async function (args) {
+                                try {
+                                    const states = await policy_lib.list_states(args.name);
+                                    let output = [`policy ${args.name}`];
+                                    if (states && states.states) {
+                                        for (const state of states.states) {
+                                            const stateDetail = await policy_lib.get_state(args.name, state.name);
+                                            if (stateDetail && stateDetail.state) {
+                                                output.push(`  state ${stateDetail.state.name}`);
+                                                if (stateDetail.state.enter_actions) {
+                                                    for (const action of stateDetail.state.enter_actions) {
+                                                        output.push(`    enter action ${action.device} ${action.action}`);
+                                                    }
+                                                }
+                                                output.push('  return');
+                                            }
+                                        }
+                                    }
+                                    output.push('return');
+                                    this.log(output.join('\n'));
+                                } catch (err) {
+                                    this.log('Error:', err.err_msg || '未知错误');
+                                }
+                            });
+
+                        // 隐藏当前视图，显示新视图
+                        vorpal.hide();
+                        newVorpal.show();
+                    } else {
+                        this.log('创建策略失败');
+                    }
+                } catch (err) {
+                    this.log('Error:', err.err_msg || err.message || '未知错误');
+                }
+            });
         vorpal.command('bdr', '列出所有配置')
             .action(async function (args) {
                 try {
@@ -22,9 +82,38 @@ export default {
         return vorpal;
     },
     make_bdr: async function () {
-        let ret = []
-        if (this._vorpalInstance) {
-            ret = ret.concat(await cli_utils.make_sub_bdr(this._vorpalInstance));
+        let ret = [];
+        // 获取所有策略
+        let pageNo = 0;
+        let policies = [];
+        while (true) {
+            const result = await policy_lib.list_policy(pageNo);
+            if (!result.policies || result.policies.length === 0) {
+                break;
+            }
+            policies = policies.concat(result.policies);
+            pageNo++;
+        }
+
+        // 遍历每个策略，获取其状态和动作
+        for (const policy of policies) {
+            ret.push(`policy ${policy.name}`);
+            const states = await policy_lib.list_states(policy.name);
+            if (states && states.states) {
+                for (const state of states.states) {
+                    const stateDetail = await policy_lib.get_state(policy.name, state.name);
+                    if (stateDetail && stateDetail.state) {
+                        ret.push(`  state ${stateDetail.state.name}`);
+                        if (stateDetail.state.enter_actions) {
+                            for (const action of stateDetail.state.enter_actions) {
+                                ret.push(`    enter action ${action.device} ${action.action}`);
+                            }
+                        }
+                        ret.push('  return');
+                    }
+                }
+            }
+            ret.push('return');
         }
         return ret;
     },

--- a/policy/cli/policy_cli.js
+++ b/policy/cli/policy_cli.js
@@ -1,7 +1,5 @@
 import cli_utils from '../../public/lib/cli_utils.js';
 import policy_detail_cli from './policy_detail_cli.js';
-import policy_lib from '../lib/policy_lib.js';
-import state_cli from './state_cli.js';
 export default {
     command: 'policy',
     name: '策略管理',
@@ -11,66 +9,8 @@ export default {
         let ins = this;
         const vorpal = cli_utils.create_vorpal();
         this._vorpalInstance = vorpal;
-        vorpal.delimiter(prompt);
-        vorpal.command('policy <name>', '创建/进入策略')
-            .action(async function (args) {
-                try {
-                    const result = await policy_lib.add_policy(args.name);
-                    if (result && result.result) {
-                        this.log(`已创建策略: ${args.name}`);
-                        // 创建新的视图实例
-                        const newVorpal = cli_utils.create_vorpal();
-                        // 注册状态命令
-                        state_cli.policy_name = args.name;
-                        cli_utils.add_sub_cli(newVorpal, state_cli, `sw_cli> policy-${args.name}>`);
-                        newVorpal.delimiter(`sw_cli> policy-${args.name}>`);
-
-                        // 添加返回命令
-                        newVorpal.command('return', '返回上一级视图')
-                            .action(function() {
-                                newVorpal.hide();
-                                vorpal.show();
-                                vorpal.delimiter('sw_cli> policy>');
-                                return vorpal;
-                            });
-
-                        // 添加 bdr 命令
-                        newVorpal.command('bdr', '列出所有配置')
-                            .action(async function (args) {
-                                try {
-                                    const states = await policy_lib.list_states(args.name);
-                                    let output = [`policy ${args.name}`];
-                                    if (states && states.states) {
-                                        for (const state of states.states) {
-                                            const stateDetail = await policy_lib.get_state(args.name, state.name);
-                                            if (stateDetail && stateDetail.state) {
-                                                output.push(`  state ${stateDetail.state.name}`);
-                                                if (stateDetail.state.enter_actions) {
-                                                    for (const action of stateDetail.state.enter_actions) {
-                                                        output.push(`    enter action ${action.device} ${action.action}`);
-                                                    }
-                                                }
-                                                output.push('  return');
-                                            }
-                                        }
-                                    }
-                                    output.push('return');
-                                    this.log(output.join('\n'));
-                                } catch (err) {
-                                    this.log('Error:', err.err_msg || '未知错误');
-                                }
-                            });
-
-                        // 隐藏当前视图，显示新视图
-                        vorpal.hide();
-                        newVorpal.show();
-                    } else {
-                        this.log('创建策略失败');
-                    }
-                } catch (err) {
-                    this.log('Error:', err.err_msg || err.message || '未知错误');
-                }
-            });
+        cli_utils.add_sub_cli(vorpal, policy_detail_cli, prompt);
+        vorpal.delimiter(prompt)
         vorpal.command('bdr', '列出所有配置')
             .action(async function (args) {
                 try {
@@ -82,38 +22,9 @@ export default {
         return vorpal;
     },
     make_bdr: async function () {
-        let ret = [];
-        // 获取所有策略
-        let pageNo = 0;
-        let policies = [];
-        while (true) {
-            const result = await policy_lib.list_policy(pageNo);
-            if (!result.policies || result.policies.length === 0) {
-                break;
-            }
-            policies = policies.concat(result.policies);
-            pageNo++;
-        }
-
-        // 遍历每个策略，获取其状态和动作
-        for (const policy of policies) {
-            ret.push(`policy ${policy.name}`);
-            const states = await policy_lib.list_states(policy.name);
-            if (states && states.states) {
-                for (const state of states.states) {
-                    const stateDetail = await policy_lib.get_state(policy.name, state.name);
-                    if (stateDetail && stateDetail.state) {
-                        ret.push(`  state ${stateDetail.state.name}`);
-                        if (stateDetail.state.enter_actions) {
-                            for (const action of stateDetail.state.enter_actions) {
-                                ret.push(`    enter action ${action.device} ${action.action}`);
-                            }
-                        }
-                        ret.push('  return');
-                    }
-                }
-            }
-            ret.push('return');
+        let ret = []
+        if (this._vorpalInstance) {
+            ret = ret.concat(await cli_utils.make_sub_bdr(this._vorpalInstance));
         }
         return ret;
     },

--- a/policy/cli/policy_detail_cli.js
+++ b/policy/cli/policy_detail_cli.js
@@ -16,6 +16,7 @@ export default {
         // 注册状态命令
         state_cli.policy_name = this.cur_view_name;
         cli_utils.add_sub_cli(vorpal, state_cli, prompt);
+        state_cli.policy_view = ins;
 
         vorpal.command('bdr', '列出所有配置')
             .action(async function (args) {
@@ -53,11 +54,11 @@ export default {
         return `策略 ${args.view_name} 已删除`;
     },
     make_bdr: async function (view_name) {
-        let ret = [`policy ${view_name}`];
+        let ret = [];
         if (this._vorpalInstance) {
+            this.cur_view_name = view_name;
             ret = ret.concat(await cli_utils.make_sub_bdr(this._vorpalInstance));
         }
-        ret.push('return');
         return ret;
     },
 }

--- a/policy/cli/policy_detail_cli.js
+++ b/policy/cli/policy_detail_cli.js
@@ -1,5 +1,7 @@
 import cli_utils from '../../public/lib/cli_utils.js';
 import policy_lib from '../lib/policy_lib.js';
+import state_cli from './state_cli.js';
+
 export default {
     command: 'policy',
     name: '创建/进入策略',
@@ -10,6 +12,11 @@ export default {
         const vorpal = cli_utils.create_vorpal();
         this._vorpalInstance = vorpal;
         this.prompt_prefix = prompt;
+
+        // 注册状态命令
+        state_cli.policy_name = this.cur_view_name;
+        cli_utils.add_sub_cli(vorpal, state_cli, prompt);
+
         vorpal.command('bdr', '列出所有配置')
             .action(async function (args) {
                 try {
@@ -46,10 +53,11 @@ export default {
         return `策略 ${args.view_name} 已删除`;
     },
     make_bdr: async function (view_name) {
-        let ret = []
+        let ret = [`policy ${view_name}`];
         if (this._vorpalInstance) {
             ret = ret.concat(await cli_utils.make_sub_bdr(this._vorpalInstance));
         }
+        ret.push('return');
         return ret;
     },
 }

--- a/policy/cli/state_cli.js
+++ b/policy/cli/state_cli.js
@@ -16,8 +16,18 @@ export default {
         vorpal.command('enter action <device> <action>', '添加进入状态时的动作')
             .action(async function (args) {
                 try {
-                    await policy_lib.add_state_action(ins.policy_name, ins.cur_view_name, 'enter', args.device, args.action);
+                    await policy_lib.add_state_action(ins.policy_view.cur_view_name, ins.cur_view_name, 'enter', args.device, args.action);
                     this.log(`已添加进入动作: 设备 ${args.device} 执行 ${args.action}`);
+                } catch (err) {
+                    this.log('Error:', err.err_msg || '未知错误');
+                }
+            });
+
+        // 添加 bdr 命令
+        vorpal.command('bdr', '列出所有配置')
+            .action(async function (args) {
+                try {
+                    this.log((await ins.make_bdr(ins.cur_view_name)).join('\n'));
                 } catch (err) {
                     this.log('Error:', err.err_msg || '未知错误');
                 }
@@ -26,7 +36,7 @@ export default {
         return vorpal;
     },
     enter_view_hook: async function (args) {
-        await policy_lib.add_state(this.policy_name, args.view_name);
+        await policy_lib.add_state(this.policy_view.cur_view_name, args.view_name);
         let prompt = this.prompt_prefix + args.view_name + '>';
 
         this._vorpalInstance.delimiter(prompt);
@@ -34,23 +44,31 @@ export default {
         return `已进入状态视图: ${prompt}`;
     },
     get_all_views: async function () {
-        return await policy_lib.list_states(this.policy_name);
+        let ret = []
+        let pageNo = 0;
+        while (true) {
+            let resp = await policy_lib.list_states(this.policy_view.cur_view_name, pageNo)
+            if (resp.states.length == 0) {
+                break;
+            }
+            ret = ret.concat(resp.states.map(state => state.name));
+            pageNo++;
+        }
+        return ret;
     },
     undo_hook: async function (args) {
-        await policy_lib.del_state(this.policy_name, args.view_name);
+        await policy_lib.del_state(this.policy_view.cur_view_name, args.view_name);
         return `状态 ${args.view_name} 已删除`;
     },
-    make_bdr: async function () {
+    make_bdr: async function (view_name) {
         let ret = [];
-        const state = await policy_lib.get_state(this.policy_name, this.cur_view_name);
-        if (state) {
-            ret.push(`  state ${this.cur_view_name}`);
-            if (state.enter_actions) {
-                for (const action of state.enter_actions) {
-                    ret.push(`    enter action ${action.device} ${action.action}`);
+        const resp = await policy_lib.get_state(this.policy_view.cur_view_name, view_name);
+        if (resp.state) {
+            if (resp.state.enter_actions) {
+                for (const action of resp.state.enter_actions) {
+                    ret.push(`  enter action ${action.device} ${action.action}`);
                 }
             }
-            ret.push('  return');
         }
         return ret;
     }

--- a/policy/cli/state_cli.js
+++ b/policy/cli/state_cli.js
@@ -1,0 +1,57 @@
+import cli_utils from '../../public/lib/cli_utils.js';
+import policy_lib from '../lib/policy_lib.js';
+
+export default {
+    command: 'state',
+    name: '创建/进入状态',
+    _vorpalInstance: null,
+    install: function (parent_prompt) {
+        let prompt = parent_prompt + 'state-';
+        let ins = this;
+        const vorpal = cli_utils.create_vorpal();
+        this._vorpalInstance = vorpal;
+        this.prompt_prefix = prompt;
+
+        // 添加进入动作命令
+        vorpal.command('enter action <device> <action>', '添加进入状态时的动作')
+            .action(async function (args) {
+                try {
+                    await policy_lib.add_state_action(ins.policy_name, ins.cur_view_name, 'enter', args.device, args.action);
+                    this.log(`已添加进入动作: 设备 ${args.device} 执行 ${args.action}`);
+                } catch (err) {
+                    this.log('Error:', err.err_msg || '未知错误');
+                }
+            });
+
+        return vorpal;
+    },
+    enter_view_hook: async function (args) {
+        await policy_lib.add_state(this.policy_name, args.view_name);
+        let prompt = this.prompt_prefix + args.view_name + '>';
+
+        this._vorpalInstance.delimiter(prompt);
+        this.cur_view_name = args.view_name;
+        return `已进入状态视图: ${prompt}`;
+    },
+    get_all_views: async function () {
+        return await policy_lib.list_states(this.policy_name);
+    },
+    undo_hook: async function (args) {
+        await policy_lib.del_state(this.policy_name, args.view_name);
+        return `状态 ${args.view_name} 已删除`;
+    },
+    make_bdr: async function () {
+        let ret = [];
+        const state = await policy_lib.get_state(this.policy_name, this.cur_view_name);
+        if (state) {
+            ret.push(`  state ${this.cur_view_name}`);
+            if (state.enter_actions) {
+                for (const action of state.enter_actions) {
+                    ret.push(`    enter action ${action.device} ${action.action}`);
+                }
+            }
+            ret.push('  return');
+        }
+        return ret;
+    }
+}

--- a/policy/lib/policy_lib.js
+++ b/policy/lib/policy_lib.js
@@ -12,8 +12,8 @@ export default {
     add_state: async function (policy_name, state_name, token) {
         return await call_remote('/policy/add_state', { policy_name, state_name }, token);
     },
-    list_states: async function (policy_name, token) {
-        return await call_remote('/policy/list_states', { policy_name }, token);
+    list_states: async function (policy_name, pageNo, token) {
+        return await call_remote('/policy/list_states', { policy_name, pageNo }, token);
     },
     del_state: async function (policy_name, state_name, token) {
         return await call_remote('/policy/del_state', { policy_name, state_name }, token);

--- a/policy/lib/policy_lib.js
+++ b/policy/lib/policy_lib.js
@@ -8,5 +8,26 @@ export default {
     },
     del_policy: async function (name, token) {
         return await call_remote('/policy/del_policy', { name }, token);
+    },
+    add_state: async function (policy_name, state_name, token) {
+        return await call_remote('/policy/add_state', { policy_name, state_name }, token);
+    },
+    list_states: async function (policy_name, token) {
+        return await call_remote('/policy/list_states', { policy_name }, token);
+    },
+    del_state: async function (policy_name, state_name, token) {
+        return await call_remote('/policy/del_state', { policy_name, state_name }, token);
+    },
+    get_state: async function (policy_name, state_name, token) {
+        return await call_remote('/policy/get_state', { policy_name, state_name }, token);
+    },
+    add_state_action: async function (policy_name, state_name, trigger, device, action, token) {
+        return await call_remote('/policy/add_state_action', { 
+            policy_name, 
+            state_name, 
+            trigger, 
+            device, 
+            action 
+        }, token);
     }
 }

--- a/policy/server/policy_module.js
+++ b/policy/server/policy_module.js
@@ -12,7 +12,7 @@ export default {
                 name: { type: String, mean: '策略名称', example: '策略1', have_to: true },
             },
             result: {
-                result: { type: Boolean, mean: '操作结果', example: true, have_to: true }
+                result: { type: Boolean, mean: '操作结果', example: true }
             },
             func: async function (body, token) {
                 try {
@@ -39,12 +39,11 @@ export default {
             is_write: false,
             is_get_api: true,
             params: {
-                pageNo: { type: Number, mean: '页码', example: 0, have_to: true }
             },
             result: {
                 policies: {
-                    type: Array, mean: '策略列表', example: [], explain: {
-                        name: { type: String, mean: '策略名称', example: '策略1', have_to: true },
+                    type: Array, mean: '策略列表', explain: {
+                        name: { type: String, mean: '策略名称', example: '策略1'},
                     }
                 }
             },
@@ -65,7 +64,7 @@ export default {
                 name: { type: String, mean: '策略名称', example: '策略1', have_to: true },
             },
             result: {
-                result: { type: Boolean, mean: '操作结果', example: true, have_to: true }
+                result: { type: Boolean, mean: '操作结果', example: true}
             },
             func: async function (body, token) {
                 let index = policy_array.findIndex(policy => policy.name === body.name);
@@ -89,7 +88,7 @@ export default {
                 state_name: { type: String, mean: '状态名称', example: 's1', have_to: true }
             },
             result: {
-                result: { type: Boolean, mean: '操作结果', example: true, have_to: true }
+                result: { type: Boolean, mean: '操作结果', example: true }
             },
             func: async function (body, token) {
                 let policy = policy_array.find(p => p.name === body.policy_name);
@@ -116,15 +115,13 @@ export default {
             is_get_api: true,
             params: {
                 policy_name: { type: String, mean: '策略名称', example: '策略1', have_to: true },
-                pageNo: { type: Number, mean: '页码', example: 0, have_to: true }
             },
             result: {
                 states: { 
                     type: Array, 
                     mean: '状态列表', 
-                    example: [], 
                     explain: {
-                        name: { type: String, mean: '状态名称', example: 's1', have_to: true }
+                        name: { type: String, mean: '状态名称', example: 's1' }
                     }
                 }
             },
@@ -145,7 +142,7 @@ export default {
             name: '获取状态',
             description: '获取状态的详细信息',
             is_write: false,
-            is_get_api: true,
+            is_get_api: false,
             params: {
                 policy_name: { type: String, mean: '策略名称', example: '策略1', have_to: true },
                 state_name: { type: String, mean: '状态名称', example: 's1', have_to: true }
@@ -154,16 +151,14 @@ export default {
                 state: { 
                     type: Object, 
                     mean: '状态信息', 
-                    example: { name: 's1', enter_actions: [] },
                     explain: {
-                        name: { type: String, mean: '状态名称', example: 's1', have_to: true },
+                        name: { type: String, mean: '状态名称', example: 's1'},
                         enter_actions: { 
                             type: Array, 
                             mean: '进入动作列表', 
-                            example: [],
                             explain: {
-                                device: { type: String, mean: '设备名称', example: '阀门1', have_to: true },
-                                action: { type: String, mean: '动作名称', example: '开启', have_to: true }
+                                device: { type: String, mean: '设备名称', example: '阀门1' },
+                                action: { type: String, mean: '动作名称', example: '开启' }
                             }
                         }
                     }

--- a/policy/server/policy_module.js
+++ b/policy/server/policy_module.js
@@ -115,7 +115,8 @@ export default {
             is_write: false,
             is_get_api: true,
             params: {
-                policy_name: { type: String, mean: '策略名称', example: '策略1', have_to: true }
+                policy_name: { type: String, mean: '策略名称', example: '策略1', have_to: true },
+                pageNo: { type: Number, mean: '页码', example: 0, have_to: true }
             },
             result: {
                 states: { 
@@ -132,8 +133,11 @@ export default {
                 if (!policy) {
                     throw { err_msg: '策略不存在' };
                 }
+                let states = policy.states ? policy.states.map(s => ({ name: s.name })) : [];
+                let current_page_content = states.slice(body.pageNo * 20, (body.pageNo + 1) * 20);
                 return {
-                    states: policy.states ? policy.states.map(s => ({ name: s.name })) : []
+                    states: current_page_content,
+                    total: states.length,
                 };
             }
         },

--- a/policy/test/state_cli.test.js
+++ b/policy/test/state_cli.test.js
@@ -50,19 +50,73 @@ describe('状态 CLI 测试', () => {
         result = await cli.run_cmd('enter action 阀门2 关闭');
         expect(result).toContain('已添加进入动作: 设备 阀门2 执行 关闭');
         
+        // 测试状态内部的 bdr 命令
+        // sw_cli> policy> policy-abc> state-s1>bdr
+        let bdr = await cli.run_cmd('bdr')
+        expect(bdr).toContain('enter action 阀门1 开启');
+        expect(bdr).toContain('enter action 阀门2 关闭');
+        
         // 返回到策略视图
         await cli.run_cmd('return');
         
         // 返回到策略管理视图
         await cli.run_cmd('return');
         
-        // 查看bdr配置输出
-        // sw_cli> policy>bdr
-        let bdr = await cli.run_cmd('bdr');
-        expect(bdr).toContain('policy abc');
-        expect(bdr).toContain('state s1');
+        bdr = await cli.run_cmd('bdr');
+        expect(bdr).toContain("policy 'abc'");
+        expect(bdr).toContain("state 's1'");
         expect(bdr).toContain('enter action 阀门1 开启');
         expect(bdr).toContain('enter action 阀门2 关闭');
         expect(bdr).toContain('return');
+    });
+
+    test('分页功能测试：创建多个状态', async () => {
+        // 创建策略test并进入策略视图
+        await cli.run_cmd('policy test');
+        
+        // 创建多个状态（超过20个以测试分页）
+        for (let i = 0; i < 25; i++) {
+            await cli.run_cmd(`state s${i}`);
+            await cli.run_cmd('return');
+        }
+        
+        // 验证所有状态都能正确列出（通过 bdr 命令）
+        let policy_bdr = await cli.run_cmd('bdr');
+        // 由于移除了状态名称显示，这里只验证策略级别的 bdr 包含状态命令
+        expect(policy_bdr).toContain("state 's0'");
+        expect(policy_bdr).toContain("state 's24'");
+        
+        // 进入其中一个状态并添加动作
+        await cli.run_cmd('state s10');
+        await cli.run_cmd('enter action 设备1 动作1');
+        
+        // 测试状态内部的 bdr
+        let state_bdr = await cli.run_cmd('bdr');
+        expect(state_bdr).toContain('enter action 设备1 动作1');
+        
+        await cli.run_cmd('return');
+        await cli.run_cmd('return');
+    });
+
+    test('状态内部命令测试', async () => {
+        // 创建策略和状态
+        await cli.run_cmd('policy test');
+        await cli.run_cmd('state s1');
+        
+        // 测试状态内部的 return 命令
+        let result = await cli.run_cmd('return');
+
+        
+        // 重新进入状态
+        await cli.run_cmd('state s1');
+        
+        // 测试空状态的 bdr
+        let bdr = await cli.run_cmd('bdr');
+        // 由于状态 s1 已经有动作了，所以 bdr 应该包含这些动作
+        expect(bdr).toContain('enter action 阀门1 开启');
+        expect(bdr).toContain('enter action 阀门2 关闭');
+        
+        await cli.run_cmd('return');
+        await cli.run_cmd('return');
     });
 });

--- a/policy/test/state_cli.test.js
+++ b/policy/test/state_cli.test.js
@@ -1,0 +1,68 @@
+import test_utils from "../../public/lib/test_utils.js";
+import { print_test_log, start_server, close_server } from "../../public/lib/test_utils.js";
+
+let cli;
+
+beforeAll(async () => {
+    print_test_log('state CLI test begin', true);
+    cli = await test_utils('npm run dev_cli');
+    await start_server();
+    await cli.run_cmd('clear');
+});
+
+afterAll(async () => {
+    await cli.run_cmd('clear');
+    await cli.close();
+    await close_server();
+    print_test_log('state CLI test end', true);
+});
+
+describe('状态 CLI 测试', () => {
+    beforeEach(async () => {
+        // 清空所有配置
+        await cli.run_cmd('clear');
+        // 进入策略管理
+        await cli.run_cmd('policy');
+    });
+
+    afterEach(async () => {
+        // 返回到根视图
+        await cli.run_cmd('return');
+        // 清空配置
+        await cli.run_cmd('clear');
+    });
+
+    test('基本功能：创建策略、状态和动作', async () => {
+        // 创建策略abc并进入策略视图
+        // sw_cli> policy> policy abc
+        await cli.run_cmd('policy abc');
+        
+        // 创建状态s1并进入状态视图
+        // sw_cli> policy> policy-abc>state s1
+        await cli.run_cmd('state s1');
+        
+        // 添加进入动作
+        // sw_cli> policy> policy-abc> state-s1>enter action 阀门1 开启
+        let result = await cli.run_cmd('enter action 阀门1 开启');
+        expect(result).toContain('已添加进入动作: 设备 阀门1 执行 开启');
+        
+        // sw_cli> policy> policy-abc> state-s1>enter action 阀门2 关闭
+        result = await cli.run_cmd('enter action 阀门2 关闭');
+        expect(result).toContain('已添加进入动作: 设备 阀门2 执行 关闭');
+        
+        // 返回到策略视图
+        await cli.run_cmd('return');
+        
+        // 返回到策略管理视图
+        await cli.run_cmd('return');
+        
+        // 查看bdr配置输出
+        // sw_cli> policy>bdr
+        let bdr = await cli.run_cmd('bdr');
+        expect(bdr).toContain('policy abc');
+        expect(bdr).toContain('state s1');
+        expect(bdr).toContain('enter action 阀门1 开启');
+        expect(bdr).toContain('enter action 阀门2 关闭');
+        expect(bdr).toContain('return');
+    });
+});

--- a/public/cli/cli_runtime_lib.js
+++ b/public/cli/cli_runtime_lib.js
@@ -3,6 +3,7 @@ import device_cli from '../../device/cli/device_management_cli.js';
 import resource_cli from '../../resource/cli/resource_cli.js';
 import policy_cli from '../../policy/cli/policy_cli.js';
 import call_remote from '../lib/call_remote.js';
+import events from 'events';
 let g_vorpal = undefined;
 let default_config_file = 'sw_cli_config.txt';
 async function make_bdr() {
@@ -14,6 +15,7 @@ async function make_bdr() {
 }
 function get_vorpal() {
     if (!g_vorpal) {
+        events.defaultMaxListeners = 1000;
         const vorpal = cli_utils.create_vorpal();
         const prompt = 'sw_cli> ';
         vorpal.command('bdr', '列出所有配置')


### PR DESCRIPTION
DPKW-20-命令行增加某个策略的状态
//创建状态1并进入状态1子视图
sw_cli> policy> policy-abc>state <s1> 

//创建两个进入状态的动作，参数是设备和动作，设备和动作都可以是任何字符串
sw_cli> policy> policy-abc> state-s1>enter action <阀门1> <开启>
sw_cli> policy> policy-abc> state-s1>enter action <阀门2> <关闭>

//可以查询到刚才的配置
sw_cli> policy>bdr
policy abc
  state s1
    enter action xxxx
    enter action xxxx
  return
return

<img width="502" height="295" alt="企业微信截图_4ae790c5-0d0b-4547-9b41-653349721639" src="https://github.com/user-attachments/assets/016c5ea5-722d-45ee-80f2-e59182f683b2" />
<img width="580" height="123" alt="image" src="https://github.com/user-attachments/assets/5b869922-a763-4bf4-a4bf-3a5d33ec6793" />

