### PR TITLE
DPKW-43-增加跨策略变量赋值

### DIFF
--- a/policy/lib/policy_lib.js
+++ b/policy/lib/policy_lib.js
@@ -98,22 +98,36 @@ export default {
     del_source: async function (policy_name, name, token) {
         return await call_remote('/policy/del_source', { policy_name, name }, token);
     },
-    add_state_assignment: async function (policy_name, state_name, trigger, variable_name, expression, token) {
-        return await call_remote('/policy/add_state_assignment', { 
+    add_assignment: async function (policy_name, state_name, trigger, variable_name, expression, target_policy_name = null, token) {
+        const params = { 
             policy_name, 
             state_name, 
             trigger, 
             variable_name, 
             expression 
-        }, token);
+        };
+        
+        // 如果是跨策略赋值，添加target_policy_name参数
+        if (target_policy_name) {
+            params.target_policy_name = target_policy_name;
+        }
+        
+        return await call_remote('/policy/add_assignment', params, token);
     },
-    del_state_assignment: async function (policy_name, state_name, trigger, variable_name, token) {
-        return await call_remote('/policy/del_state_assignment', { 
+    del_assignment: async function (policy_name, state_name, trigger, variable_name, target_policy_name = null, token) {
+        const params = { 
             policy_name, 
             state_name, 
             trigger, 
             variable_name 
-        }, token);
+        };
+        
+        // 如果是跨策略赋值，添加target_policy_name参数
+        if (target_policy_name) {
+            params.target_policy_name = target_policy_name;
+        }
+        
+        return await call_remote('/policy/del_assignment', params, token);
     },
     set_scan_period: async function (period_ms, token) {
         return await call_remote('/policy/set_scan_period', { period_ms }, token);


### PR DESCRIPTION
1.添加跨策略变量赋值功能
2.修改变量赋值接口改为根据参数判断是策略内赋值还是跨策略赋值
3.添加变量赋值中如果是不垮策略需要验证var_name是否存在，之前只判断是否重复。加了存在。如果是跨策略添加变量赋值，则对俩个参数都不做是否存在的校验。
<img width="630" height="234" alt="image" src="https://github.com/user-attachments/assets/914d8037-c9b2-4606-bc71-38f650c1d074" />

